### PR TITLE
Updating gitignore to allow Validation Review .Rmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,9 @@ Output_ThreeDefs/*
 
 # Ignore Validation Review Folders (except for SupportCode/Validation_Review which includes template code)
 **/Validation_Review/
-!SupportCode/Validation_Review 
+!SupportCode/Validation_Review/Validation_Summary.Rmd
+!SupportCode/Validation_Review/Validation_Summary_Pre_Consensus_Review.Rmd
+!SupportCode/Validation_Review/Validation_Summary_Post_Consensus_Review.Rmd
 
 # Ignore Knitted Syndrome Validation Templates
 *.html

--- a/.gitignore
+++ b/.gitignore
@@ -62,11 +62,13 @@ Output_OneDefs/*
 Output_TwoDefs/*
 Output_ThreeDefs/*
 
-# Ignore Validation Review Folders (except for SupportCode/Validation_Review which includes template code)
-**/Validation_Review/
-!SupportCode/Validation_Review/Validation_Summary.Rmd
-!SupportCode/Validation_Review/Validation_Summary_Pre_Consensus_Review.Rmd
-!SupportCode/Validation_Review/Validation_Summary_Post_Consensus_Review.Rmd
+# Ignore all files in Validation_Review subfolders
+**/Validation_Review/*
+
+# Except for the specific Rmd files
+!**/Validation_Review/Validation_Summary.Rmd
+!**/Validation_Review/Validation_Summary_Pre_Consensus_Review.Rmd
+!**/Validation_Review/Validation_Summary_Post_Consensus_Review.Rmd
 
 # Ignore Knitted Syndrome Validation Templates
 *.html

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Syndrome Definition Evaluation Toolkit
 
 > [!NOTE]
-> If you are planning to use this tool for syndrome development, I would recommed starting with the steps laid out in the [Syndrome Definition Guidance document](https://prod-knowledge-repository.s3-us-gov-west-1.amazonaws.com/references/SDC_Syndrome%20Definition%20Guidance%20document_FINAL.PDF) prior to starting with this tool. This document was developed by members of the NSSP Syndrome Definition Committee with the purpose of providing a recommended protocol for developing and testing a new syndrome definition. This tool is particularly useful and revelant to the "Refining the Syndrome" section of the document.
+> If you are planning to use this tool for syndrome development, I would recommed starting with the steps laid out in the [Syndrome Definition Development Toolkit](https://knowledgerepository.syndromicsurveillance.org/syndrome-definition-development-toolkit) prior to starting with this tool. This document was developed by members of the NSSP Syndrome Definition Committee in collaboration with the CDC NSSP team for the purpose of providing a recommended protocol for developing and testing a new syndrome definition. This tool is particularly useful and revelant to the "Iterative Testing and Validation" and "External Validation" sections of the document.
 
 ## Authors:
 1. [Sara Chronister](sara.chronister@doh.wa.gov), Washington State Department of Health - Rapid Health Information NetwOrk (RHINO)
@@ -10,25 +10,25 @@
 ## Background:
 The purpose of this tool is to allow ESSENCE users to evaluate the data details (line level) results of one, two, or three syndrome definitions at a time. This project produces several important outputs: 
 1. An **HTML report** that can be shared with others and opened using either Chrome or Firefox browsers. This document contains no identifiable data, only aggregate results, for security purposes.
-2. A **.csv file** for each combination of definitions possible containing a subset of variables important in the manual review process. These files do contain identifiable information and should be handled accordingly.
-3. A **.csv file** containing details about the definition elements (codes and terms) that can be used to evaluate the performance of individual elements in query results. These files do contain identifiable information and should be handled accordingly.
-4. One or multiple **.xlsx file(s)** containing details about records captured by provided definitions that can be used to facilitate manual reviews and a consensus decision-making process to calculate query performance metrics by one or multiple reviewers. These files do contain identifiable information and should be handled accordingly.
+2. A **.csv file** for each combination of definitions possible containing a subset of variables important in the manual review process. These files contain identifiable information and should be handled accordingly.
+3. A **.csv file** containing details about the definition elements (codes and terms) that can be used to evaluate the performance of individual elements in query results. These files contain identifiable information and should be handled accordingly.
+4. One or multiple **.xlsx file(s)** containing details about records captured by provided definitions that can be used to facilitate manual reviews and a consensus decision-making process to calculate query performance metrics by one or multiple reviewers. These files contain identifiable information and should be handled accordingly.
 
 ## Instructions:
 
 ### 1) Download and set up files:
 * Download the project files by clicking the green "Code" button and selecting "Download ZIP".
-* Unzip the files to the location that you want the project files to be stored.
+* Unzip the files to the location that you want the project files to be stored. This will be your Working Directory for this project.
 
 ### 2) In Excel:
 * Open the `"DefinitionInformationTable.xlsx"` file.
 * **Follow the instructions for setting up the evaluation in all tabs.** Detailed information about each of the fields is in the top row. **DO NOT CHANGE THE LOCATIONS OF ANY OF THE FIELDS**. The program will fail if you do.
-* Keep in mind that if you want to evaluate one definition, you must update the def1 row of the "DefinitionInformation" tab. For evaluation of two definitions, update the def1 and def2 rows, and for three definitions update all rows in the "DefinitionInformation" tab. 
-* Save (without changing the name of the file) once you have all the information you need about your definitions.
+* Keep in mind that if you want to evaluate one definition, you must update the def1 row of the "DefinitionInformation" tab. For evaluation of two definitions, update the def1 and def2 rows, and for three definitions update the def1, def2, and def3 rows in the "DefinitionInformation" tab. Additional definition information may be saved/stored in subsequent rows, which may be helpful for record-keeping purposes, but only the information in the three defX rows will be used for their respective evaluations.
+* Save (without changing the name of the file) once you have entered all the information you need about your definitions.
 
 ### 3) In RStudio: 
-* In your file location, open the `"SyndromeEvaluation.Rproj"` file.
-* To run the tool, open `"run_tool.R"`.
+* In your Working Directory file location, open the `"SyndromeEvaluation.Rproj"` file.
+* Open `"run_tool.R"`.
 
 > [!IMPORTANT]  
 > * Edit the `n_queries_eval` object in the `"run_tool.R"` code (line 12) to either be `1`, `2`, or `3`. This will determine the number of definitions you are evaluating.
@@ -38,12 +38,12 @@ The purpose of this tool is to allow ESSENCE users to evaluate the data details 
 >      + To run the code, you can click the "Run" button (top right corner of the R script window) or use the following shortcuts (Windows: ctrl+Enter, macOS: command+return).
 
 ## Accessing Toolkit Results:
-* Result files from this tool will be available in the `Output` subfolder, and will be organized by the number of definitions you are evaluating.
-   + When a One, Two, or Three definition syndrome definition evaluation is run, their results will be stored in the respective filepaths: `Output/OneDef/`, `Output/TwoDefs/`, `Output/ThreeDefs/`.
-   + If a One, Two, or Three definition syndrome evaluation has not yet been run, these filepaths will not yet exist.
+* Result files from this tool will be available in the `Output` subfolder of your Working Directory file location, and will be organized by the number of definitions you are evaluating.
+   + When a One, Two, or Three definition evaluation is run, their results will be stored in the respective filepaths: `Output/OneDef/`, `Output/TwoDefs/`, `Output/ThreeDefs/`.
+   + If a One, Two, or Three definition evaluation has not yet been run, these filepaths will not yet exist.
 
 ### Results Files & Folders
-1. `Syndrome Evaluation Report.html` - The **main syndrome definition evaluation report** which includes syndrome definition syntax, volumes of emergency department visits, demographics, and the relative overlap between multiple syndromic definitions.
+1. `Syndrome Evaluation Report.html` - The **main syndrome definition evaluation report** which includes syndrome definition syntax, visit volumes, demographics, and the relative overlap between multiple syndromic definitions.
 2. `[INSERT_CUSTOM_NAME].RData` - This `.RData` file will flexibly named by pasting together the abbreviations of the definitions being evaluated by the tool (see example below). It contains all of the data written to the `Definition_Comparison` and `Matched_Elements` subfolders, in a single, easy-to-access file for R users to access. This may be useful for R users to load instead of trying to work with many disparate `.xlsx` files.
    + Example: A 2 syndrome definition evaluation report is run for AIRQUAL (Air Quality-related Respiratory Illness v1) and ILI (Influenza Like Illness), the `.RData` file name would be `AIRQUAL_ILI.RData`.
 4. `Definition_Comparison` subfolder - Contains `.xlsx` files of ESSENCE DataDetails records based on the syndrome definition(s) (singular or multiple overlap) they fall under. These may be useful for separate, custom analyses.

--- a/Scripts/2_process_data.R
+++ b/Scripts/2_process_data.R
@@ -333,7 +333,8 @@ if(params$validation_review$enable_validation_review == TRUE){
     
     
     # Step 4b: Save Parameter Files to All Validation Review Folders
-    save(params, file = paste0(params$filepaths$validation_review,"/", params$queries_abbrev[i],"/Resources/Parameters.RData"))
+    save(params, DefinitionInformation,
+         file = paste0(params$filepaths$validation_review,"/", params$queries_abbrev[i],"/Resources/Parameters.RData"))
   }
 }
 

--- a/Scripts/SupportCode/1-PackageManagement.R
+++ b/Scripts/SupportCode/1-PackageManagement.R
@@ -23,6 +23,7 @@ pacman::p_load(
   readxl,
   rmarkdown,
   Rnssp,
+  rstudioapi,
   splitstackshape,
   stringr,
   tictoc,

--- a/Scripts/SupportCode/1-PackageManagement.R
+++ b/Scripts/SupportCode/1-PackageManagement.R
@@ -15,6 +15,7 @@ pacman::p_load(
   forcats,
   fs,
   gtsummary,
+  here,
   janitor,
   lubridate,
   magrittr,

--- a/Scripts/SupportCode/5-CleanData.R
+++ b/Scripts/SupportCode/5-CleanData.R
@@ -35,7 +35,8 @@ clean_demographics <- function(df){
       mutate(Sex = case_when(
         Sex == "M" ~ "Male",
         Sex == "F" ~ "Female",
-        Sex == "U" ~ "Unknown"),
+        Sex == "U" ~ "Unknown",
+        TRUE ~ "Unknown"),
         Sex = factor(Sex, levels = c("Female", "Male", "Unknown")))
     }
   

--- a/Scripts/SupportCode/Validation_Review/Validation_Summary.Rmd
+++ b/Scripts/SupportCode/Validation_Review/Validation_Summary.Rmd
@@ -67,7 +67,7 @@ assign_review_label <- function(df, review_scale_low = ReviewScaleLow, review_sc
 prep_cm <- function(df, use_case){
   
   df_prepped <- df %>%
-    mutate(Definition = "Positive", # Prediction Variable (aka whether the query tagged/identified the record) --> Will always be 1. 
+    mutate(Definition = "Positive", # Prediction Variable (aka whether the syndrome definition tagged/identified the record) --> Will always be 1. 
          Definition = factor(Definition, levels = c("Positive", "Negative")))
   
   if(use_case == "reviewer"){
@@ -170,7 +170,7 @@ ReviewScale <- cut_review_scale(scale_low = ReviewScaleLow, scale_high = ReviewS
 
 # Extract Definition Undergoing Validation Review (from filepath)
 definition_abbrev <- str_extract(string = rstudioapi::getActiveDocumentContext()$path, # Gets the filepath of currently active R Markdown
-                          pattern = paste0(params$queries_abbrev, collapse = "|")) # Extract query abbreviation from that filepath
+                          pattern = paste0(params$queries_abbrev, collapse = "|")) # Extract syndrome definition abbreviation from that filepath
 ```
 
 ```{r Load in All Reviewer Data}
@@ -286,7 +286,7 @@ if(n_reviewers == 1){
   
   cat(paste0(
     '# Instructions\n',
-    'After rendering this R Markdown report, query performance metrics will be generated below (**Note: ** Records assigned the **Uncertain** review category will not be included in query performance metric calculations).',
+    'After rendering this R Markdown report, syndrome definition performance metrics will be generated below (**Note: ** Records assigned the **Uncertain** review category will not be included in syndrome definition performance metric calculations).',
     '<br> <br>'
   ))
   
@@ -294,7 +294,7 @@ if(n_reviewers == 1){
   
   cat(paste0(
     '# Consensus Review Instructions\n',
-    'After rendering this R Markdown report, validation reviews by each of the participating reviewers will be compared to assess agreement and disagreement for each reviewed record. Additionally, query performance metrics (by reviewer) and interrater reliability metrics will be generated below. These metrics have been provided to assess how closely aligned participants were in their validation reviews and address any issues that may have emerged during the validation review process. (Note: Records assigned the **Uncertain** review category will not be included in query performance metric calculations). \n',
+    'After rendering this R Markdown report, validation reviews by each of the participating reviewers will be compared to assess agreement and disagreement for each reviewed record. Additionally, syndrome definition performance metrics (by reviewer) and interrater reliability metrics will be generated below. These metrics have been provided to assess how closely aligned participants were in their validation reviews and address any issues that may have emerged during the validation review process. (Note: Records assigned the **Uncertain** review category will not be included in syndrome definition performance metric calculations). \n',
     'When you are ready to discuss validation review findings and come to a consensus decision among the participating reviewers (particularly for records where there were disagreements), access the following file:  **2_Consensus_Data/Consensus_Data.xlsx**.\n',
     '\n',
     '[Within **Consensus_Data.xlsx**:]{.underline}\n',
@@ -303,7 +303,7 @@ if(n_reviewers == 1){
     '- After a consensus decision has been made, fill in the **Review_Category_Consensus** variable with the agreed upon review category.\n',
     '- (*Optional; if helpful*) Fill out the **Notes_Consensus** to explain which reviewer(s) changed their review category and rating upon coming to a consensus decision. This documentation will provide clarity as to how disagreements were resolved and what pieces of information may be useful to informing final record classifications\n',
     '\n',
-    'After completing the consensus review process and running **Validation_Summary_Post_Consensus_Review.Rmd**, query performance metrics (utilizing consensus review categories) will be generated. Additionally, **Consensus_Data.xlsx** will be copied and subset to remove the no longer needed *Reviewer* variables. This data will be called **Consensus_Data_Subset.xlsx**.',
+    'After completing the consensus review process and running **Validation_Summary_Post_Consensus_Review.Rmd**, syndrome definition performance metrics (utilizing consensus review categories) will be generated. Additionally, **Consensus_Data.xlsx** will be copied and subset to remove the no longer needed *Reviewer* variables. This data will be called **Consensus_Data_Subset.xlsx**.',
     '<br> <br>'
     ))
 }
@@ -555,7 +555,7 @@ for(i in 1:n_reviewers){
 
 if(length(ReviewScale) == 2){ # TP, FP
   
-  query_performance_template <- c(
+  definition_performance_template <- c(
     "```{r, echo=FALSE, results='asis'}\n",
     "cat(
     paste0('## ', 'Reviewer ', {{i}},' (',DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'))",
@@ -568,11 +568,11 @@ if(length(ReviewScale) == 2){ # TP, FP
   
 }else if(length(ReviewScale) == 3){ # TP, Uncertain, FP
   
-    query_performance_template <- c(
+    definition_performance_template <- c(
     "```{r, echo=FALSE, results='asis'}\n",
     "cat(
     paste0('## ', 'Reviewer ',{{i}},' (', DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'),
-    paste0('**Note: ** Records with the review category of **Uncertain** are excluded from query performance calculations.', '\n'))",
+    paste0('**Note: ** Records with the review category of **Uncertain** are excluded from syndrome definition performance calculations.', '\n'))",
     "```\n",
     "\n",
     "```{r}\n", # Initializes R code to create 1) Tabbed Widget and 2) Insert ES Text.
@@ -581,11 +581,11 @@ if(length(ReviewScale) == 2){ # TP, FP
     "\n")
 }
 
-reviewer_query_performance <- lapply(seq_along(list_reviewer), function(i) {knitr::knit_expand(text= query_performance_template)}) # Use query_performance_template above, and render it via knitr::knit_expand()
+reviewer_definition_performance <- lapply(seq_along(list_reviewer), function(i) {knitr::knit_expand(text= definition_performance_template)}) # Use definition_performance_template above, and render it via knitr::knit_expand()
 
 ```
 
-`r knitr::knit(text = unlist(reviewer_query_performance))`
+`r knitr::knit(text = unlist(reviewer_definition_performance))`
 
 ```{r Write Reviewer RData File}
 if(n_reviewers == 1){

--- a/Scripts/SupportCode/Validation_Review/Validation_Summary.Rmd
+++ b/Scripts/SupportCode/Validation_Review/Validation_Summary.Rmd
@@ -1,0 +1,599 @@
+---
+output: 
+  html_document:
+    toc: true
+    toc_float: true
+---
+
+<!-- Setup -->
+
+```{r Custom Functions, echo=FALSE}
+
+## Function 1a: Cut Review Scale into Categories (function used inside 2b)
+
+cut_review_scale <- function(scale_low, scale_high){
+  
+  rating_scale <- seq(from = scale_low, to = scale_high, by = 1) # Create rating scale vector (of integers)
+  scale_length <- length(rating_scale)
+  n_chunks <- ifelse((scale_length %% 2) == 0, 2, 3)  # scale_length %% 2 is 0 for even length scales and 1 for odd length scales
+
+  rating_categories <- list()
+  
+  if(n_chunks == 2){ # FP = scale_low to first half of rating_scale; TP = second half of rating_scale to scale_high
+    
+    rating_categories[["False Positive"]] <- seq(from = scale_low, to = rating_scale[(scale_length/2)], by = 1)
+    rating_categories[["True Positive"]] <- seq(from = rating_scale[((scale_length/2))+1], to = scale_high, by = 1)
+    
+  }else if(n_chunks == 3){ # FP = scale_low to 1 before median of rating_scale; Uncertain = median value of rating scale; TP = 1 after median of rating scale to scale_high. 
+    
+    rating_categories[["False Positive"]] <- seq(from = scale_low, to = (median(rating_scale) - 1), by = 1)
+    rating_categories[["Uncertain"]] <- median(rating_scale)
+    rating_categories[["True Positive"]] <- seq(from = (median(rating_scale) + 1), to = scale_high, by = 1)
+  }
+  
+  return(rating_categories)
+}
+
+## Function 1b: Assign Category labels to data frame
+
+assign_review_label <- function(df, review_scale_low = ReviewScaleLow, review_scale_high = ReviewScaleHigh){
+  
+  # Create Rating Categories
+  rating_categories <- cut_review_scale(scale_low = review_scale_low, scale_high = review_scale_high)
+  
+  # Assign Rating Category Labels
+  if(length(rating_categories) == 2){ # If review_scale was even, only FP/TP (No Uncertain)
+    
+    df_labelled <- df %>%
+      mutate(Review_Category = case_when(
+        Review_Rating %in% rating_categories[["False Positive"]] ~ "False Positive",
+        Review_Rating %in% rating_categories[["True Positive"]] ~ "True Positive"))
+    
+  }else if(length(rating_categories) == 3){ # If review_scale was odd, FP/Uncertain/TP
+    
+    df_labelled <- df %>%
+      mutate(Review_Category = case_when(
+        Review_Rating %in% rating_categories[["False Positive"]] ~ "False Positive",
+        Review_Rating %in% rating_categories[["Uncertain"]] ~ "Uncertain",
+        Review_Rating %in% rating_categories[["True Positive"]] ~ "True Positive"))
+  }
+  
+  # Return labelled data frame to global environment
+  return(df_labelled)
+}
+
+## Function 2: Prepare data for caret::confusionMatrix()
+
+prep_cm <- function(df, use_case){
+  
+  df_prepped <- df %>%
+    mutate(Definition = "Positive", # Prediction Variable (aka whether the query tagged/identified the record) --> Will always be 1. 
+         Definition = factor(Definition, levels = c("Positive", "Negative")))
+  
+  if(use_case == "reviewer"){
+    
+    df_prepped <- df_prepped %>%
+      mutate(across(
+        .cols = matches("^Review_Category"),
+        .fns = ~factor(.x, 
+                       levels = c("True Positive", "False Positive"), 
+                       labels = c("Positive", "Negative"))))
+    
+  }else if(use_case == "consensus"){
+    
+    df_prepped <- df_prepped %>%
+      mutate(Review_Category_Consensus = factor(Review_Category_Consensus, # caret requires ordered factors 
+                                      levels = c("True Positive", "False Positive"), 
+                                      labels = c("Positive", "Negative"))) # shorten factor labels
+  }
+
+return(df_prepped)
+}
+
+## Function 3: Modified caret::confusionMatrix()
+
+confusion_matrix <- function(df, use_case){
+  
+  # Step 0: Generate storage list
+  list_storage <- list()
+  
+  # Step 1: Generate caret::confusionMatrix()
+  if(use_case == "reviewer"){
+     CM <- caret::confusionMatrix(data = df$Definition, # Query detected record?
+                               reference = df$Review_Category) # Query classification accurate?  
+     
+  }else if(use_case == "consensus"){
+     CM <- caret::confusionMatrix(data = df$Definition, reference = df$Review_Category_Consensus) 
+  }
+
+  # Step 2: Extract caret 2x2 table from CM
+  list_storage[["table"]] <- CM$table
+  
+  # Step 3: Extract PPV & Accuracy (95% CI) from CM
+  list_storage[["metrics"]] <- broom::tidy(CM) %>%
+    filter(term %in% c("accuracy", "pos_pred_value")) %>% # Only metrics we want to keep
+    mutate(across(.cols = where(is.numeric), .fns = ~ round(.x, digits = 2))) %>% # Round metrics to 2 decimals
+    mutate(value = ifelse(!is.na(conf.low) & !is.na(conf.high),
+                          paste0(estimate," (",conf.low,", ",conf.high,")"), estimate), # Combine CI w/estimate
+           term = case_when( # Relabel terms/metrics
+             term == "pos_pred_value" ~  "positive predictive value (PPV)",
+             term == "accuracy" ~ "accuracy (95% CI)",
+             TRUE ~ term)) %>%
+    arrange(desc(term)) %>% # Display PPV first then Accuracy. 
+    select(metric = term, value) %>%
+    as.data.frame() # Convert to DF to allow printing. 
+  
+  
+  if(use_case == "consensus"){
+    print(list_storage)
+  }
+  
+  return(list_storage)
+}
+```
+
+
+```{r Setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+
+load("Resources\\Parameters.RData")
+
+if ("pacman" %in% rownames(installed.packages()) == FALSE) {
+  install.packages("pacman")
+}
+
+library(pacman)
+
+pacman::p_load(broom,
+               caret,
+               gtsummary,
+               irr,
+               readxl,
+               tidyverse,
+               writexl)
+
+### Recreate Needed Evaluation_[X]Defs Parameters from DefinitionInformation
+
+# Number of Validation Reviewers
+n_reviewers <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewerID %>% max()
+
+# ESSENCE fields included
+select_fields <- DefinitionInformation[["SelectFields"]] %>% filter(IncludeForValidationReview == "Yes") %>% pull(ESSENCEfields)
+
+# Jurisdiction of Validation Reviewers
+jurisdiction <- DefinitionInformation[["Setup"]]$Jurisdiction
+
+# Review Scale: High/Low
+ReviewScaleLow <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewScaleLow[1]
+ReviewScaleHigh <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewScaleHigh[1]
+ReviewScale <- cut_review_scale(scale_low = ReviewScaleLow, scale_high = ReviewScaleHigh)
+
+# Extract Definition Undergoing Validation Review (from filepath)
+definition_abbrev <- str_extract(string = rstudioapi::getActiveDocumentContext()$path, # Gets the filepath of currently active R Markdown
+                          pattern = paste0(params$queries_abbrev, collapse = "|")) # Extract query abbreviation from that filepath
+```
+
+```{r Load in All Reviewer Data}
+
+list_reviewer <- list()
+
+for(i in 1:n_reviewers){
+
+list_reviewer[[i]] <- readxl::read_excel(path = paste0("1_Reviewed_Data\\Reviewer_",i,"\\Reviewer_",i,"_Data.xlsx")) %>%
+  assign_review_label(df=.)
+
+names(list_reviewer)[[i]] <- paste0("Reviewer_",i)
+}
+
+# Save for Confusion Matrix Generation (line ~460)
+list_reviewer_cm <- list_reviewer 
+
+```
+
+```{r Join All Reviewer Data}
+if(n_reviewers > 1){
+  
+# Full Join All Reviewer Data Frames
+
+# Note: Each data frame will have added (_R#) suffixes added to their review columns. These suffixes can be used to identify individual reviewers once all of their review variables are joined together. (Ex: We have 3 reviewers you will see Review_Ratings_R[1-3], Review_Categories_R[1-3], Notes_R[1-3]).
+
+# Step 1: Set Aside Demographic and Clinical Variables
+demo_clinical <- list_reviewer[[1]] %>% # Using 1st data frame (exact same records and values across all reviewer DFs)
+    select(all_of(select_fields), -ends_with("\\_R[0-9]*")) # Select Validation Review fields, remove Rating vars. 
+
+
+# Step 2: Assign Reviewer ID (_R#) Suffixes to Each Reviewer Variable (to allow us to distinguish when all ratings are joined together)
+
+for(i in seq_along(list_reviewer)){
+  
+  list_reviewer[[i]] <- list_reviewer[[i]] %>%
+    rename_with(.data =.,
+                .cols = c(Review_Rating, Review_Category, Notes),
+                .fn = ~paste0(.,"_R",i))
+}
+
+# Step 3: Subset List Reviewer DFs to only 1) Date, 2) C_BioSense_ID, and Rating Variables.
+list_reviewer_ratings <- list()
+
+for(i in seq_along(list_reviewer)){
+  
+  list_reviewer_ratings[[i]] <- list_reviewer[[i]] %>%
+    select(Date, C_BioSense_ID, ends_with(paste0("R",i)))
+}
+  
+  
+# Step 4: Full Join Reviewer Ratings Together, Reorder Variables, and Left Join in Demographic and Clinical Variables
+
+comparison <- list_reviewer_ratings %>%
+  reduce(full_join, by = c("Date", "C_BioSense_ID")) %>%
+  # Reorder Variables: Needed to Create the Agreement Variable.
+  select(Date, C_BioSense_ID,
+         matches("Review\\_Rating"), ## Review_Rating(_R#) variable
+         matches("Review\\_Category"), # Reviewer_Category(_R#) variable
+         matches("^Notes"), # Notes(_R#) variable
+         everything()) %>%
+  left_join(., demo_clinical, by = join_by(Date, C_BioSense_ID))
+
+
+rm(list_reviewer_ratings)
+}
+```
+
+```{r Detect Agreements and Disagreements}
+if(n_reviewers > 1){
+  
+comparison <- comparison %>%
+  rowwise() %>%
+  mutate(Agreement =
+           all(c_across(Review_Category_R1:!!(paste0("Review_Category_R",n_reviewers))) ==
+                 first(c_across(Review_Category_R1:!!(paste0("Review_Category_R",n_reviewers))))), # Agreement assess the IRR of Qualitative Review Categories (FP/Uncertain/TP),
+         Date = as.Date(Date)) %>% 
+  ### Reorder variables ###
+  select(Date, C_BioSense_ID, Agreement, everything())
+
+}
+```
+
+<!-- Write Data -->
+
+```{r Write Consensus Dataset}
+if(n_reviewers > 1){
+ 
+  comparison %>%
+  arrange(Agreement) %>% # Disagreements at the top
+  mutate(Review_Category_Consensus = case_when(
+    Agreement == TRUE ~ Review_Category_R1,
+    TRUE ~ NA),
+    Notes_Consensus = ifelse(Agreement == TRUE, "-", NA)) %>%
+  select(Date, C_BioSense_ID, Agreement, Review_Category_Consensus, Notes_Consensus, everything()) %>%
+  writexl::write_xlsx(x=.,path = paste0("2_Consensus_Data\\Consensus_Data.xlsx")) 
+  
+}
+```
+
+---
+title: "Validation Summary: `r definition_abbrev`"
+---
+
+**Jurisdiction**: `r jurisdiction`  
+**Report Created**: `r Sys.Date()`    
+**Point of Contact**: `r DefinitionInformation[["Setup"]]$PointOfContact` (`r DefinitionInformation[["Setup"]]$POCEmail`)    
+**Organization**: `r DefinitionInformation[["Setup"]]$Organization`
+
+
+```{r Instructions Text, results= 'asis'}
+if(n_reviewers == 1){
+  
+  cat(paste0(
+    '# Instructions\n',
+    'After rendering this R Markdown report, query performance metrics will be generated below (**Note: ** Records assigned the **Uncertain** review category will not be included in query performance metric calculations).',
+    '<br> <br>'
+  ))
+  
+}else if(n_reviewers > 1){
+  
+  cat(paste0(
+    '# Consensus Review Instructions\n',
+    'After rendering this R Markdown report, validation reviews by each of the participating reviewers will be compared to assess agreement and disagreement for each reviewed record. Additionally, query performance metrics (by reviewer) and interrater reliability metrics will be generated below. These metrics have been provided to assess how closely aligned participants were in their validation reviews and address any issues that may have emerged during the validation review process. (Note: Records assigned the **Uncertain** review category will not be included in query performance metric calculations). \n',
+    'When you are ready to discuss validation review findings and come to a consensus decision among the participating reviewers (particularly for records where there were disagreements), access the following file:  **2_Consensus_Data/Consensus_Data.xlsx**.\n',
+    '\n',
+    '[Within **Consensus_Data.xlsx**:]{.underline}\n',
+    '\n',
+    '- Discuss records where there are disagreements between the participating reviewers (i.e. records where the **Agreement** variable will be **FALSE**).\n',
+    '- After a consensus decision has been made, fill in the **Review_Category_Consensus** variable with the agreed upon review category.\n',
+    '- (*Optional; if helpful*) Fill out the **Notes_Consensus** to explain which reviewer(s) changed their review category and rating upon coming to a consensus decision. This documentation will provide clarity as to how disagreements were resolved and what pieces of information may be useful to informing final record classifications\n',
+    '\n',
+    'After completing the consensus review process and running **Validation_Summary_Post_Consensus_Review.Rmd**, query performance metrics (utilizing consensus review categories) will be generated. Additionally, **Consensus_Data.xlsx** will be copied and subset to remove the no longer needed *Reviewer* variables. This data will be called **Consensus_Data_Subset.xlsx**.',
+    '<br> <br>'
+    ))
+}
+
+```
+
+```{r Assessing Interrater Reliability Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('# Assessing Interrater Reliability  {.tabset}\n',
+           'Examining the initial agreement between the participating reviewers (**before Consensus Review**) can provide some insight into the reliability of the reviewer metrics as well as how difficult the reviewed definition was to classify. ')
+    )
+}
+```
+
+```{r Reviewer Distributions Setup}
+if(n_reviewers > 1){
+
+list_reviewer_comparison <- list()
+
+# To Showcase Distribution of Review Categories and Review Scales by Rater
+list_reviewer_comparison[["rating_categories"]] <- comparison %>%
+  select(C_BioSense_ID, matches("^Review_Category")) %>%
+  pivot_longer(data =., 
+               cols = contains("Review_Category"),
+               names_to = "Reviewer",
+               values_to = "Rating_Categories") %>%
+  mutate(Reviewer = str_replace_all(Reviewer, pattern = "Review_Category_R", replacement = "Reviewer "))
+
+list_reviewer_comparison[["rating_scales"]] <- comparison %>%
+  select(C_BioSense_ID, matches("^Review_Rating")) %>%
+  pivot_longer(data =., 
+               cols = contains("Review_Rating"),
+               names_to = "Reviewer",
+               values_to = "Rating_Scale") %>%
+  mutate(Reviewer = str_replace_all(Reviewer, pattern = "Review_Rating_R", replacement = "Reviewer "))
+
+
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["rating_categories"]] %>%
+  left_join(., list_reviewer_comparison[["rating_scales"]], by = join_by("C_BioSense_ID", "Reviewer")) %>%
+  mutate(Rating_Scale = factor(Rating_Scale,
+                                 levels = seq(from = ReviewScaleLow, to = ReviewScaleHigh, by = 1)))
+
+if(length(ReviewScale) == 2){
+  
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["distributions"]] %>%
+    mutate(Rating_Categories = factor(Rating_Categories, levels = c("False Positive", "True Positive")))
+  
+}else if(length(ReviewScale) == 3){
+  
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["distributions"]] %>%
+    mutate(Rating_Categories = factor(Rating_Categories, levels = c("False Positive", "Uncertain","True Positive")))
+  
+}
+
+}
+```
+
+```{r Reviewer Distributions Text, results = 'asis'}
+if(n_reviewers > 1){
+
+cat(
+    paste0('## Reviewer Distributions\n',
+           'This sections examines the overall distributions of review categories (qualitative labels) and review ratings (quantitative values) applied by each reviewer.'
+    )
+  )
+  
+}
+```
+
+```{r Reviewer Distributions}
+if(n_reviewers > 1){
+
+list_reviewer_comparison[["distributions"]] %>% 
+  select(-C_BioSense_ID, `Rating Categories` = Rating_Categories, `Rating Scale` = Rating_Scale) %>%
+  tbl_summary(by = Reviewer,
+              missing_text = "Missing") %>%
+  add_p() %>%
+  add_overall(last=TRUE) %>%
+  modify_header(label ~ "") %>%
+  bold_labels()
+
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+```{r IRR Setup}
+if(n_reviewers > 1){
+ 
+# Generate Storage List
+list_reviewer_IRR <- list()
+
+# To Generate IRR Metrics
+
+comparison_IRR <- comparison %>%
+  select(matches("^Review_Rating")) # Include only the review columns with assigned values on the rating scale, removes other variables (ex: Review_TP_15_[REVIEWER#]). 
+  
+}
+```
+
+```{r Percent Agreement Review Categories Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('## Percent Agreement: Review Categories\n',
+           'This section examines the level of agreement across the **broad, qualitative review categories** applied to each record. For this validation review, the following review categories were utilized: ')
+  )
+}
+```
+
+```{r Print Review Categories}
+if(n_reviewers > 1){
+
+print(names(ReviewScale))
+
+}
+```
+
+```{r Percent Agreement Review Categories}
+if(n_reviewers > 1){
+
+n_agree <- comparison %>% filter(Agreement == TRUE) %>% nrow()
+n_sample <- comparison %>% nrow()
+pcnt_agree <- round((n_agree/n_sample)*100,1)
+
+list_reviewer_IRR[["Percent Agreement: Review Categories"]] <- paste0("Interrater Agreement:\n Records: ",n_sample,"\n Raters: ", n_reviewers,"\n %-agree: ", pcnt_agree)
+
+cat(list_reviewer_IRR[["Percent Agreement: Review Categories"]]) 
+  
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+```{r Percent Agreement Review Ratings Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('## Percent Agreement: Review Ratings\n',
+           'This section examines the level of agreement across the **specific, quantitative review ratings** applied to each record. For this validation review, review ratings were nested within the review categories using the following schema: ')
+  )
+}
+```
+
+```{r Print ReviewScale}
+if(n_reviewers > 1){
+  
+  print(ReviewScale)
+}
+```
+
+```{r Percent Agreement Review Scales}
+if(n_reviewers > 1){
+
+(list_reviewer_IRR[["Percent Agreement: Review Ratings"]] <- comparison_IRR %>% irr::agree(.))
+
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+`r if(n_reviewers == 2){paste0('## ','Cohens Kappa: Review Scales')}`
+`r if(n_reviewers > 2){paste0('## ','Lights Kappa: Review Scales')}`
+
+```{r Kappa Review Scales Text, results='asis'}
+if(n_reviewers > 1){
+  
+  cat(
+    paste0("Although Percent Agreement is a simple metric to quickly examine Interrater Reliability, it has a notable weakness. **Percent Agreement does not adjust for the level of agreement that would be expected by random chance, and therefore overestimates the level of agreement between reviewers**. The [Kappa statistic](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3402032/) is utilized to adress this weakness and can have values that range from 1 to -1. [Guidelines for examining Kappa values have suggested the following interpretation (although this may differ by use case):]{.underline}
+
+* **-1 to -0.1**: Agreement is worse than random (active disagreement)
+* **0 to 0.2**: Slight Agreement
+* **0.21 to 0.4**: Fair Agreement
+* **0.41 to 0.60**: Moderate Agreement
+* **0.61 to 0.80**: Substantial Agreement
+* **0.81 to 1.0**: Almost Perfect or Perfect Agreement"
+  ))
+  
+}
+```
+
+```{r Kappa Review Scales Description, results='asis'}
+if(n_reviewers == 2){
+  
+  cat("The Kappa statistic presented below is **Cohen's Kappa statistic** which was developed to assess interrater reliability between **2** reviewers.")
+  
+}else if(n_reviewers > 2){
+  
+  cat("The Kappa statistic presented below is **Light's Kappa statistic** developed to assess interrater reliability between **3+** reviewers. Specifically, Light's Kappa statistic is calculated by taking the average of the Cohen's Kappa stastic between all possible 2 reviewer pairs.")
+  
+}
+
+```
+
+```{r Quant Review Scale Kappa, warning = FALSE}
+
+# 3) Cohen's & Light's Kappa
+# Source: (Discussing appropriate use of IRR statistics) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3402032/
+
+if(n_reviewers == 2){ # Cohen's original Kappa only appropriate for 2 reviewers
+
+  (list_reviewer_IRR[["Cohen's Kappa"]] <- comparison_IRR %>% irr::kappa2(.))
+
+}else if(n_reviewers > 2){ # Light's Kappa - Average of all possible combinations of 2x2 Cohen Kappa's
+
+  (list_reviewer_IRR[["Light's Kappa"]] <- comparison_IRR %>% irr::kappam.light(.))
+}
+
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+# Query Performance (by Reviewer) {.tabset}
+
+```{r Query Performance by Reviewer}
+
+# Step 1: Prepare Data for Confusion Matrix
+
+for(i in 1:n_reviewers){
+  
+  list_reviewer_cm[[i]] <- list_reviewer_cm[[i]] %>% 
+    prep_cm(df=., use_case = "reviewer")
+}
+
+# Step 2: Dynamically Render Query Performance by Review Tabbed Widgets using list_reviewer. SOURCE: https://stackoverflow.com/questions/42631642/creating-dynamic-tabs-in-rmarkdown
+
+if(length(ReviewScale) == 2){ # TP, FP
+  
+  query_performance_template <- c(
+    "```{r, echo=FALSE, results='asis'}\n",
+    "cat(
+    paste0('## ', 'Reviewer ', {{i}},' (',DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'))",
+    "```\n",
+    "\n",
+    "```{r}\n", # Initializes R code to create 1) Tabbed Widget and 2) Insert ES Text.
+    "list_reviewer_cm[[{{i}}]] %>% confusion_matrix(df=., use_case = 'reviewer')", # Print confusion matrix
+    "```\n", # Ends R Code and adds a space (to differentiate tabbed widgets)
+    "\n")
+  
+}else if(length(ReviewScale) == 3){ # TP, Uncertain, FP
+  
+    query_performance_template <- c(
+    "```{r, echo=FALSE, results='asis'}\n",
+    "cat(
+    paste0('## ', 'Reviewer ',{{i}},' (', DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'),
+    paste0('**Note: ** Records with the review category of **Uncertain** are excluded from query performance calculations.', '\n'))",
+    "```\n",
+    "\n",
+    "```{r}\n", # Initializes R code to create 1) Tabbed Widget and 2) Insert ES Text.
+    "list_reviewer_cm[[{{i}}]] %>% confusion_matrix(df=., use_case = 'reviewer')", # Print confusion matrix
+    "```\n", # Ends R Code and adds a space (to differentiate tabbed widgets)
+    "\n")
+}
+
+reviewer_query_performance <- lapply(seq_along(list_reviewer), function(i) {knitr::knit_expand(text= query_performance_template)}) # Use query_performance_template above, and render it via knitr::knit_expand()
+
+```
+
+`r knitr::knit(text = unlist(reviewer_query_performance))`
+
+```{r Write Reviewer RData File}
+if(n_reviewers == 1){
+  
+    save(list_reviewer, list_reviewer_cm, file = "1_Reviewed_Data\\Reviewer_Data.RData")
+  
+}else if(n_reviewers > 1){
+  
+  save(list_reviewer, list_reviewer_comparison, list_reviewer_cm, list_reviewer_IRR, file = "1_Reviewed_Data\\Reviewer_Data.RData")
+}
+```

--- a/Scripts/SupportCode/Validation_Review/Validation_Summary_Post_Consensus_Review.Rmd
+++ b/Scripts/SupportCode/Validation_Review/Validation_Summary_Post_Consensus_Review.Rmd
@@ -1,0 +1,629 @@
+---
+output: 
+  html_document:
+    toc: true
+    toc_float: true
+---
+
+<!-- Setup -->
+
+```{r Custom Functions, echo=FALSE}
+
+## Function 1a: Cut Review Scale into Categories (function used inside 2b)
+
+cut_review_scale <- function(scale_low, scale_high){
+  
+  rating_scale <- seq(from = scale_low, to = scale_high, by = 1) # Create rating scale vector (of integers)
+  scale_length <- length(rating_scale)
+  n_chunks <- ifelse((scale_length %% 2) == 0, 2, 3)  # scale_length %% 2 is 0 for even length scales and 1 for odd length scales
+
+  rating_categories <- list()
+  
+  if(n_chunks == 2){ # FP = scale_low to first half of rating_scale; TP = second half of rating_scale to scale_high
+    
+    rating_categories[["False Positive"]] <- seq(from = scale_low, to = rating_scale[(scale_length/2)], by = 1)
+    rating_categories[["True Positive"]] <- seq(from = rating_scale[((scale_length/2))+1], to = scale_high, by = 1)
+    
+  }else if(n_chunks == 3){ # FP = scale_low to 1 before median of rating_scale; Uncertain = median value of rating scale; TP = 1 after median of rating scale to scale_high. 
+    
+    rating_categories[["False Positive"]] <- seq(from = scale_low, to = (median(rating_scale) - 1), by = 1)
+    rating_categories[["Uncertain"]] <- median(rating_scale)
+    rating_categories[["True Positive"]] <- seq(from = (median(rating_scale) + 1), to = scale_high, by = 1)
+  }
+  
+  return(rating_categories)
+}
+
+## Function 1b: Assign Category labels to data frame
+
+assign_review_label <- function(df, review_scale_low = ReviewScaleLow, review_scale_high = ReviewScaleHigh){
+  
+  # Create Rating Categories
+  rating_categories <- cut_review_scale(scale_low = review_scale_low, scale_high = review_scale_high)
+  
+  # Assign Rating Category Labels
+  if(length(rating_categories) == 2){ # If review_scale was even, only FP/TP (No Uncertain)
+    
+    df_labelled <- df %>%
+      mutate(Review_Category = case_when(
+        Review_Rating %in% rating_categories[["False Positive"]] ~ "False Positive",
+        Review_Rating %in% rating_categories[["True Positive"]] ~ "True Positive"))
+    
+  }else if(length(rating_categories) == 3){ # If review_scale was odd, FP/Uncertain/TP
+    
+    df_labelled <- df %>%
+      mutate(Review_Category = case_when(
+        Review_Rating %in% rating_categories[["False Positive"]] ~ "False Positive",
+        Review_Rating %in% rating_categories[["Uncertain"]] ~ "Uncertain",
+        Review_Rating %in% rating_categories[["True Positive"]] ~ "True Positive"))
+  }
+  
+  # Return labelled data frame to global environment
+  return(df_labelled)
+}
+
+## Function 2: Prepare data for caret::confusionMatrix()
+
+prep_cm <- function(df, use_case){
+  
+  df_prepped <- df %>%
+    mutate(Definition = "Positive", # Prediction Variable (aka whether the Syndrome Definition tagged/identified the record) --> Will always be 1. 
+         Definition = factor(Definition, levels = c("Positive", "Negative")))
+  
+  if(use_case == "reviewer"){
+    
+    df_prepped <- df_prepped %>%
+      mutate(across(
+        .cols = matches("^Review_Category"),
+        .fns = ~factor(.x, 
+                       levels = c("True Positive", "False Positive"), 
+                       labels = c("Positive", "Negative"))))
+    
+  }else if(use_case == "consensus"){
+    
+    df_prepped <- df_prepped %>%
+      mutate(Review_Category_Consensus = factor(Review_Category_Consensus, # caret requires ordered factors 
+                                      levels = c("True Positive", "False Positive"), 
+                                      labels = c("Positive", "Negative"))) # shorten factor labels
+  }
+
+return(df_prepped)
+}
+
+## Function 3: Modified caret::confusionMatrix()
+
+confusion_matrix <- function(df, use_case){
+  
+  # Step 0: Generate storage list
+  list_storage <- list()
+  
+  # Step 1: Generate caret::confusionMatrix()
+  if(use_case == "reviewer"){
+     CM <- caret::confusionMatrix(data = df$Definition, # Syndrome Definition detected record?
+                               reference = df$Review_Category) # Syndrome Definition classification accurate?  
+     
+  }else if(use_case == "consensus"){
+     CM <- caret::confusionMatrix(data = df$Definition, reference = df$Review_Category_Consensus) 
+  }
+
+  # Step 2: Extract caret 2x2 table from CM
+  list_storage[["table"]] <- CM$table
+  
+  # Step 3: Extract PPV & Accuracy (95% CI) from CM
+  list_storage[["metrics"]] <- broom::tidy(CM) %>%
+    filter(term %in% c("accuracy", "pos_pred_value")) %>% # Only metrics we want to keep
+    mutate(across(.cols = where(is.numeric), .fns = ~ round(.x, digits = 2))) %>% # Round metrics to 2 decimals
+    mutate(value = ifelse(!is.na(conf.low) & !is.na(conf.high),
+                          paste0(estimate," (",conf.low,", ",conf.high,")"), estimate), # Combine CI w/estimate
+           term = case_when( # Relabel terms/metrics
+             term == "pos_pred_value" ~  "positive predictive value (PPV)",
+             term == "accuracy" ~ "accuracy (95% CI)",
+             TRUE ~ term)) %>%
+    arrange(desc(term)) %>% # Display PPV first then Accuracy. 
+    select(metric = term, value) %>%
+    as.data.frame() # Convert to DF to allow printing. 
+  
+  
+  if(use_case == "consensus"){
+    print(list_storage)
+  }
+  
+  return(list_storage)
+}
+```
+
+```{r Setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+
+load("Resources\\Parameters.RData")
+
+if ("pacman" %in% rownames(installed.packages()) == FALSE) {
+  install.packages("pacman")
+}
+
+library(pacman)
+
+pacman::p_load(broom,
+               caret,
+               gtsummary,
+               irr,
+               readxl,
+               tidyverse,
+               writexl)
+
+### Recreate Needed Evaluation_[X]Defs Parameters from DefinitionInformation
+
+# Number of Validation Reviewers
+n_reviewers <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewerID %>% max()
+
+# ESSENCE fields included
+select_fields <- DefinitionInformation[["SelectFields"]] %>% filter(IncludeForValidationReview == "Yes") %>% pull(ESSENCEfields)
+
+# Jurisdiction of Validation Reviewers
+jurisdiction <- DefinitionInformation[["Setup"]]$Jurisdiction
+
+# Review Scale: High/Low
+ReviewScaleLow <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewScaleLow[1]
+ReviewScaleHigh <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewScaleHigh[1]
+ReviewScale <- cut_review_scale(scale_low = ReviewScaleLow, scale_high = ReviewScaleHigh)
+
+# Extract Defintion Undergoing Validation Review 
+definition_abbrev <- str_extract(string = rstudioapi::getActiveDocumentContext()$path, # Gets the filepath of currently active R Markdown
+                          pattern = paste0(params$queries_abbrev, collapse = "|")) # Extract Syndrome Definition abbreviation from that filepath
+```
+
+```{r Load in All Reviewer Data}
+
+list_reviewer <- list()
+
+for(i in 1:n_reviewers){
+
+list_reviewer[[i]] <- readxl::read_excel(path = paste0("1_Reviewed_Data\\Reviewer_",i,"\\Reviewer_",i,"_Data.xlsx")) %>%
+  assign_review_label(df=.)
+
+names(list_reviewer)[[i]] <- paste0("Reviewer_",i)
+}
+
+# Save for Confusion Matrix Generation (line ~460)
+list_reviewer_cm <- list_reviewer 
+
+```
+
+```{r Join All Reviewer Data}
+if(n_reviewers > 1){
+  
+# Full Join All Reviewer Data Frames
+
+# Note: Each data frame will have added (_R#) suffixes added to their review columns. These suffixes can be used to identify individual reviewers once all of their review variables are joined together. (Ex: We have 3 reviewers you will see Review_Ratings_R[1-3], Review_Categories_R[1-3], Notes_R[1-3]).
+
+# Step 1: Set Aside Demographic and Clinical Variables
+demo_clinical <- list_reviewer[[1]] %>% # Using 1st data frame (exact same records and values across all reviewer DFs)
+    select(all_of(select_fields), -ends_with("\\_R[0-9]*")) # Select Validation Review fields, remove Rating vars. 
+
+
+# Step 2: Assign Reviewer ID (_R#) Suffixes to Each Reviewer Variable (to allow us to distinguish when all ratings are joined together)
+
+for(i in seq_along(list_reviewer)){
+  
+  list_reviewer[[i]] <- list_reviewer[[i]] %>%
+    rename_with(.data =.,
+                .cols = c(Review_Rating, Review_Category, Notes),
+                .fn = ~paste0(.,"_R",i))
+}
+
+# Step 3: Subset List Reviewer DFs to only 1) Date, 2) C_BioSense_ID, and Rating Variables.
+list_reviewer_ratings <- list()
+
+for(i in seq_along(list_reviewer)){
+  
+  list_reviewer_ratings[[i]] <- list_reviewer[[i]] %>%
+    select(Date, C_BioSense_ID, ends_with(paste0("R",i)))
+}
+  
+  
+# Step 4: Full Join Reviewer Ratings Together, Reorder Variables, and Left Join in Demographic and Clinical Variables
+
+comparison <- list_reviewer_ratings %>%
+  reduce(full_join, by = c("Date", "C_BioSense_ID")) %>%
+  # Reorder Variables: Needed to Create the Agreement Variable.
+  select(Date, C_BioSense_ID,
+         matches("Review\\_Rating"), ## Review_Rating(_R#) variable
+         matches("Review\\_Category"), # Reviewer_Category(_R#) variable
+         matches("^Notes"), # Notes(_R#) variable
+         everything()) %>%
+  left_join(., demo_clinical, by = join_by(Date, C_BioSense_ID))
+  
+
+rm(list_reviewer_ratings)
+}
+```
+
+```{r Detect Agreements and Disagreements}
+if(n_reviewers > 1){
+  
+comparison <- comparison %>%
+  rowwise() %>%
+  mutate(Agreement =
+           all(c_across(Review_Category_R1:!!(paste0("Review_Category_R",n_reviewers))) ==
+                 first(c_across(Review_Category_R1:!!(paste0("Review_Category_R",n_reviewers))))), # Agreement assess the IRR of Qualitative Review Categories (FP/Uncertain/TP),
+         Date = as.Date(Date)) %>% 
+  ### Reorder variables ###
+  select(Date, C_BioSense_ID, Agreement, everything())
+
+}
+```
+
+---
+title: "Validation Summary (Post Consensus Review): `r definition_abbrev`"
+---
+
+**Jurisdiction**: `r jurisdiction`  
+**Report Created**: `r Sys.Date()`    
+**Point of Contact**: `r DefinitionInformation[["Setup"]]$PointOfContact` (`r DefinitionInformation[["Setup"]]$POCEmail`)    
+**Organization**: `r DefinitionInformation[["Setup"]]$Organization`
+
+
+```{r Instructions Text, results= 'asis'}
+if(n_reviewers == 1){
+  
+  cat(paste0(
+    '# Instructions\n',
+    'After rendering this R Markdown report, syndrome definition performance metrics will be generated below.(Note: Records assigned the **Uncertain** review category will not be included in syndrome definition performance metric calculations). There is no need to run **Validation_Summary_Post_Consensus_Review.Rmd** unless you wish to conduct an additional validation review cycle with multiple participating reviewers.',
+    '<br> <br>'
+  ))
+  
+}else if(n_reviewers > 1){
+  
+  cat(paste0(
+    '# Consensus Review Instructions\n',
+    'After rendering this R Markdown report, validation reviews by each of the participating reviewers will be compared to assess agreement and disagreement for each reviewed record. Additionally, syndrome definition performance metrics (by reviewer) and interrater reliability metrics will be generated below. These metrics have been provided to assess how closely aligned participants were in their validation reviews and address any issues that may have emerged during the validation review process. (Note: Records assigned the **Uncertain** review category will not be included in syndrome definition performance metric calculations). \n',
+    'After completing the consensus review process and running **Validation_Summary_Post_Consensus_Review.Rmd**, syndrome definition performance metrics (utilizing consensus review categories) will be generated. Additionally, **Consensus_Data.xlsx** will processed and finalized for further use (removal of no-longer need *Reviewer* variables). This data will be called **Consensus_Data_Subset.xlsx**.',
+    '<br> <br>'
+    ))
+}
+
+```
+
+```{r Assessing Interrater Reliability Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('# Assessing Interrater Reliability  {.tabset}\n',
+           'Examining the initial agreement between the participating reviewers (**before Consensus Review**) can provide some insight into the reliability of the reviewer metrics as well as how difficult the reviewed definition was to classify. ')
+    )
+}
+```
+
+```{r Reviewer Distributions Setup}
+if(n_reviewers > 1){
+
+list_reviewer_comparison <- list()
+
+# To Showcase Distribution of Review Categories and Review Scales by Rater
+list_reviewer_comparison[["rating_categories"]] <- comparison %>%
+  select(C_BioSense_ID, matches("^Review_Category")) %>%
+  pivot_longer(data =., 
+               cols = contains("Review_Category"),
+               names_to = "Reviewer",
+               values_to = "Rating_Categories") %>%
+  mutate(Reviewer = str_replace_all(Reviewer, pattern = "Review_Category_R", replacement = "Reviewer "))
+
+list_reviewer_comparison[["rating_scales"]] <- comparison %>%
+  select(C_BioSense_ID, matches("^Review_Rating")) %>%
+  pivot_longer(data =., 
+               cols = contains("Review_Rating"),
+               names_to = "Reviewer",
+               values_to = "Rating_Scale") %>%
+  mutate(Reviewer = str_replace_all(Reviewer, pattern = "Review_Rating_R", replacement = "Reviewer "))
+
+
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["rating_categories"]] %>%
+  left_join(., list_reviewer_comparison[["rating_scales"]], by = join_by("C_BioSense_ID", "Reviewer")) %>%
+  mutate(Rating_Scale = factor(Rating_Scale,
+                                 levels = seq(from = ReviewScaleLow, to = ReviewScaleHigh, by = 1)))
+
+if(length(ReviewScale) == 2){
+  
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["distributions"]] %>%
+    mutate(Rating_Categories = factor(Rating_Categories, levels = c("False Positive", "True Positive")))
+  
+}else if(length(ReviewScale) == 3){
+  
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["distributions"]] %>%
+    mutate(Rating_Categories = factor(Rating_Categories, levels = c("False Positive", "Uncertain","True Positive")))
+  
+}
+
+}
+```
+
+```{r Reviewer Distributions Text, results = 'asis'}
+if(n_reviewers > 1){
+
+cat(
+    paste0('## Reviewer Distributions\n',
+           'This sections examines the overall distributions of review categories (qualitative labels) and review ratings (quantitative values) applied by each reviewer.'
+    )
+  )
+  
+}
+```
+
+```{r Reviewer Distributions}
+if(n_reviewers > 1){
+
+list_reviewer_comparison[["distributions"]] %>% 
+  select(-C_BioSense_ID, `Rating Categories` = Rating_Categories, `Rating Scale` = Rating_Scale) %>%
+  tbl_summary(by = Reviewer,
+              missing_text = "Missing") %>%
+  add_p() %>%
+  add_overall(last=TRUE) %>%
+  modify_header(label ~ "") %>%
+  bold_labels()
+
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+```{r IRR Setup}
+if(n_reviewers > 1){
+ 
+# Generate Storage List
+list_reviewer_IRR <- list()
+
+# To Generate IRR Metrics
+
+comparison_IRR <- comparison %>%
+  select(matches("^Review_Rating")) # Include only the review columns with assigned values on the rating scale, removes other variables (ex: Review_TP_15_[REVIEWER#]). 
+  
+}
+```
+
+```{r Percent Agreement Review Categories Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('## Percent Agreement: Review Categories\n',
+           'This section examines the level of agreement across the **broad, qualitative review categories** applied to each record. For this validation review, the following review categories were utilized: ')
+  )
+}
+```
+
+```{r Print Review Categories}
+if(n_reviewers > 1){
+
+print(names(ReviewScale))
+
+}
+```
+
+```{r Percent Agreement Review Categories}
+if(n_reviewers > 1){
+
+n_agree <- comparison %>% filter(Agreement == TRUE) %>% nrow()
+n_sample <- comparison %>% nrow()
+pcnt_agree <- round((n_agree/n_sample)*100,1)
+
+list_reviewer_IRR[["Percent Agreement: Review Categories"]] <- paste0("Interrater Agreement:\n Records: ",n_sample,"\n Raters: ", n_reviewers,"\n %-agree: ", pcnt_agree)
+
+cat(list_reviewer_IRR[["Percent Agreement: Review Categories"]]) 
+  
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+```{r Percent Agreement Review Ratings Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('## Percent Agreement: Review Ratings\n',
+           'This section examines the level of agreement across the **specific, quantitative review ratings** applied to each record. For this validation review, review ratings were nested within the review categories using the following schema: ')
+  )
+}
+```
+
+```{r Print ReviewScale}
+if(n_reviewers > 1){
+  
+  print(ReviewScale)
+}
+```
+
+```{r Percent Agreement Review Scales}
+if(n_reviewers > 1){
+
+(list_reviewer_IRR[["Percent Agreement: Review Ratings"]] <- comparison_IRR %>% irr::agree(.))
+
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+`r if(n_reviewers == 2){paste0('## ','Cohens Kappa: Review Scales')}`
+`r if(n_reviewers > 2){paste0('## ','Lights Kappa: Review Scales')}`
+
+```{r Kappa Review Scales Text, results='asis'}
+if(n_reviewers > 1){
+  
+  cat(
+    paste0("Although Percent Agreement is a simple metric to quickly examine Interrater Reliability, it has a notable weakness. **Percent Agreement does not adjust for the level of agreement that would be expected by random chance, and therefore overestimates the level of agreement between reviewers**. The [Kappa statistic](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3402032/) is utilized to adress this weakness and can have values that range from 1 to -1. [Guidelines for examining Kappa values have suggested the following interpretation (although this may differ by use case):]{.underline}
+
+* **-1 to -0.1**: Agreement is worse than random (active disagreement)
+* **0 to 0.2**: Slight Agreement
+* **0.21 to 0.4**: Fair Agreement
+* **0.41 to 0.60**: Moderate Agreement
+* **0.61 to 0.80**: Substantial Agreement
+* **0.81 to 1.0**: Almost Perfect or Perfect Agreement"
+  ))
+  
+}
+```
+
+```{r Kappa Review Scales Description, results='asis'}
+if(n_reviewers == 2){
+  
+  cat("The Kappa statistic presented below is **Cohen's Kappa statistic** which was developed to assess interrater reliability between **2** reviewers.")
+  
+}else if(n_reviewers > 2){
+  
+  cat("The Kappa statistic presented below is **Light's Kappa statistic** developed to assess interrater reliability between **3+** reviewers. Specifically, Light's Kappa statistic is calculated by taking the average of the Cohen's Kappa stastic between all possible 2 reviewer pairs.")
+  
+}
+
+```
+
+```{r Quant Review Scale Kappa, warning = FALSE}
+
+# 3) Cohen's & Light's Kappa
+# Source: (Discussing appropriate use of IRR statistics) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3402032/
+
+if(n_reviewers == 2){ # Cohen's original Kappa only appropriate for 2 reviewers
+
+  (list_reviewer_IRR[["Cohen's Kappa"]] <- comparison_IRR %>% irr::kappa2(.))
+
+}else if(n_reviewers > 2){ # Light's Kappa - Average of all possible combinations of 2x2 Cohen Kappa's
+
+  (list_reviewer_IRR[["Light's Kappa"]] <- comparison_IRR %>% irr::kappam.light(.))
+}
+
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+# Syndrome Definition Performance (by Reviewer) {.tabset}
+
+```{r Syndrome Definition Performance by Reviewer}
+
+# Step 1: Prepare Data for Confusion Matrix
+
+for(i in 1:n_reviewers){
+  
+  list_reviewer_cm[[i]] <- list_reviewer_cm[[i]] %>% 
+    prep_cm(df=., use_case = "reviewer")
+}
+
+# Step 2: Dynamically Render syndrome definition Performance by Review Tabbed Widgets using list_reviewer. SOURCE: https://stackoverflow.com/questions/42631642/creating-dynamic-tabs-in-rmarkdown
+
+if(length(ReviewScale) == 2){ # TP, FP
+  
+  definition_performance_template <- c(
+    "```{r, echo=FALSE, results='asis'}\n",
+    "cat(
+    paste0('## ', 'Reviewer ', {{i}},' (',DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'))",
+    "```\n",
+    "\n",
+    "```{r}\n", # Initializes R code to create 1) Tabbed Widget and 2) Insert ES Text.
+    "list_reviewer_cm[[{{i}}]] %>% confusion_matrix(df=., use_case = 'reviewer')", # Print confusion matrix
+    "```\n", # Ends R Code and adds a space (to differentiate tabbed widgets)
+    "\n")
+  
+}else if(length(ReviewScale) == 3){ # TP, Uncertain, FP
+  
+    definition_performance_template <- c(
+    "```{r, echo=FALSE, results='asis'}\n",
+    "cat(
+    paste0('## ', 'Reviewer ',{{i}},' (', DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'),
+    paste0('**Note: ** Records with the review category of **Uncertain** are excluded from syndrome definition performance calculations.', '\n'))",
+    "```\n",
+    "\n",
+    "```{r}\n", # Initializes R code to create 1) Tabbed Widget and 2) Insert ES Text.
+    "list_reviewer_cm[[{{i}}]] %>% confusion_matrix(df=., use_case = 'reviewer')", # Print confusion matrix
+    "```\n", # Ends R Code and adds a space (to differentiate tabbed widgets)
+    "\n")
+}
+
+reviewer_definition_performance <- lapply(seq_along(list_reviewer), function(i) {knitr::knit_expand(text= definition_performance_template)}) # Use definition_performance_template above, and render it via knitr::knit_expand()
+
+```
+
+`r knitr::knit(text = unlist(reviewer_definition_performance))`
+
+```{r Write Reviewer RData File}
+if(n_reviewers == 1){
+  
+    save(list_reviewer, list_reviewer_cm, file = "1_Reviewed_Data\\Reviewer_Data.RData")
+  
+}else if(n_reviewers > 1){
+  
+  save(list_reviewer, list_reviewer_comparison, list_reviewer_cm, list_reviewer_IRR, file = "1_Reviewed_Data\\Reviewer_Data.RData")
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+  )
+}
+```
+
+```{r Syndrome Definition Performance Consensus Text, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('# Syndrome Definition Performance (Consensus) \n',
+           'Examining definitions using a consensus review framework may provide less-biased estimates than those of an individual reviewer as multiple backgrounds, skill sets, and perspectives are included in the classification of a record. **Note: ** Records with the review category of **Uncertain** are excluded from syndrome definition performance calculations.')
+  )
+}
+```
+
+```{r Syndrome Definition Performance Consensus}
+if(n_reviewers > 1){
+  
+  # Generate Storage List
+  list_consensus <- list()
+  
+  # Read in Consensus Data (Post-Consensus Review)
+  list_consensus[["Consensus_Data"]] <- readxl::read_excel(path = paste0("2_Consensus_Data\\Consensus_Data.xlsx")) 
+  
+  # Prepare Consensus Data for Confusion Matrix
+  consensus_cm <- list_consensus[["Consensus_Data"]] %>% 
+    prep_cm(df=., use_case = "consensus")
+  
+  # Generate Confusion Matrix
+  list_consensus[["Confusion_Matrix"]] <- consensus_cm %>%
+    confusion_matrix(df=., use_case = "consensus")
+}
+```
+
+```{r Write Subset Consensus Data}
+if(n_reviewers > 1){
+  
+  # Generate Consensus Data Clean (Remove Unnecessary Review Variables)
+  list_consensus[["Consensus_Data_Final"]] <- list_consensus[["Consensus_Data"]] %>% 
+    arrange(Review_Category_Consensus) %>%
+    select(-Agreement, -Notes_Consensus, 
+           -matches("^Review_Rating"),
+           -matches("^Review_Category\\_R[0-9]?"),
+           -matches("^Notes"))  # Remove all Reviewer Variables (except Consensus_Label)
+  
+  # Write Excel File
+  writexl::write_xlsx(list_consensus[["Consensus_Data_Final"]], path = "2_Consensus_Data\\Consensus_Data_Final.xlsx")
+  
+  # Write RData file
+  save(list_consensus, file = "2_Consensus_Data\\Consensus.RData")
+  
+}
+```

--- a/Scripts/SupportCode/Validation_Review/Validation_Summary_Pre_Consensus_Review.Rmd
+++ b/Scripts/SupportCode/Validation_Review/Validation_Summary_Pre_Consensus_Review.Rmd
@@ -1,0 +1,599 @@
+---
+output: 
+  html_document:
+    toc: true
+    toc_float: true
+---
+
+<!-- Setup -->
+
+```{r Custom Functions, echo=FALSE}
+
+## Function 1a: Cut Review Scale into Categories (function used inside 2b)
+
+cut_review_scale <- function(scale_low, scale_high){
+  
+  rating_scale <- seq(from = scale_low, to = scale_high, by = 1) # Create rating scale vector (of integers)
+  scale_length <- length(rating_scale)
+  n_chunks <- ifelse((scale_length %% 2) == 0, 2, 3)  # scale_length %% 2 is 0 for even length scales and 1 for odd length scales
+
+  rating_categories <- list()
+  
+  if(n_chunks == 2){ # FP = scale_low to first half of rating_scale; TP = second half of rating_scale to scale_high
+    
+    rating_categories[["False Positive"]] <- seq(from = scale_low, to = rating_scale[(scale_length/2)], by = 1)
+    rating_categories[["True Positive"]] <- seq(from = rating_scale[((scale_length/2))+1], to = scale_high, by = 1)
+    
+  }else if(n_chunks == 3){ # FP = scale_low to 1 before median of rating_scale; Uncertain = median value of rating scale; TP = 1 after median of rating scale to scale_high. 
+    
+    rating_categories[["False Positive"]] <- seq(from = scale_low, to = (median(rating_scale) - 1), by = 1)
+    rating_categories[["Uncertain"]] <- median(rating_scale)
+    rating_categories[["True Positive"]] <- seq(from = (median(rating_scale) + 1), to = scale_high, by = 1)
+  }
+  
+  return(rating_categories)
+}
+
+## Function 1b: Assign Category labels to data frame
+
+assign_review_label <- function(df, review_scale_low = ReviewScaleLow, review_scale_high = ReviewScaleHigh){
+  
+  # Create Rating Categories
+  rating_categories <- cut_review_scale(scale_low = review_scale_low, scale_high = review_scale_high)
+  
+  # Assign Rating Category Labels
+  if(length(rating_categories) == 2){ # If review_scale was even, only FP/TP (No Uncertain)
+    
+    df_labelled <- df %>%
+      mutate(Review_Category = case_when(
+        Review_Rating %in% rating_categories[["False Positive"]] ~ "False Positive",
+        Review_Rating %in% rating_categories[["True Positive"]] ~ "True Positive"))
+    
+  }else if(length(rating_categories) == 3){ # If review_scale was odd, FP/Uncertain/TP
+    
+    df_labelled <- df %>%
+      mutate(Review_Category = case_when(
+        Review_Rating %in% rating_categories[["False Positive"]] ~ "False Positive",
+        Review_Rating %in% rating_categories[["Uncertain"]] ~ "Uncertain",
+        Review_Rating %in% rating_categories[["True Positive"]] ~ "True Positive"))
+  }
+  
+  # Return labelled data frame to global environment
+  return(df_labelled)
+}
+
+## Function 2: Prepare data for caret::confusionMatrix()
+
+prep_cm <- function(df, use_case){
+  
+  df_prepped <- df %>%
+    mutate(Definition = "Positive", # Prediction Variable (aka whether the syndrome definition tagged/identified the record) --> Will always be 1. 
+         Definition = factor(Definition, levels = c("Positive", "Negative")))
+  
+  if(use_case == "reviewer"){
+    
+    df_prepped <- df_prepped %>%
+      mutate(across(
+        .cols = matches("^Review_Category"),
+        .fns = ~factor(.x, 
+                       levels = c("True Positive", "False Positive"), 
+                       labels = c("Positive", "Negative"))))
+    
+  }else if(use_case == "consensus"){
+    
+    df_prepped <- df_prepped %>%
+      mutate(Review_Category_Consensus = factor(Review_Category_Consensus, # caret requires ordered factors 
+                                      levels = c("True Positive", "False Positive"), 
+                                      labels = c("Positive", "Negative"))) # shorten factor labels
+  }
+
+return(df_prepped)
+}
+
+## Function 3: Modified caret::confusionMatrix()
+
+confusion_matrix <- function(df, use_case){
+  
+  # Step 0: Generate storage list
+  list_storage <- list()
+  
+  # Step 1: Generate caret::confusionMatrix()
+  if(use_case == "reviewer"){
+     CM <- caret::confusionMatrix(data = df$Definition, # syndrome definition detected record?
+                               reference = df$Review_Category) # syndrome definition classification accurate?  
+     
+  }else if(use_case == "consensus"){
+     CM <- caret::confusionMatrix(data = df$Definition, reference = df$Review_Category_Consensus) 
+  }
+
+  # Step 2: Extract caret 2x2 table from CM
+  list_storage[["table"]] <- CM$table
+  
+  # Step 3: Extract PPV & Accuracy (95% CI) from CM
+  list_storage[["metrics"]] <- broom::tidy(CM) %>%
+    filter(term %in% c("accuracy", "pos_pred_value")) %>% # Only metrics we want to keep
+    mutate(across(.cols = where(is.numeric), .fns = ~ round(.x, digits = 2))) %>% # Round metrics to 2 decimals
+    mutate(value = ifelse(!is.na(conf.low) & !is.na(conf.high),
+                          paste0(estimate," (",conf.low,", ",conf.high,")"), estimate), # Combine CI w/estimate
+           term = case_when( # Relabel terms/metrics
+             term == "pos_pred_value" ~  "positive predictive value (PPV)",
+             term == "accuracy" ~ "accuracy (95% CI)",
+             TRUE ~ term)) %>%
+    arrange(desc(term)) %>% # Display PPV first then Accuracy. 
+    select(metric = term, value) %>%
+    as.data.frame() # Convert to DF to allow printing. 
+  
+  
+  if(use_case == "consensus"){
+    print(list_storage)
+  }
+  
+  return(list_storage)
+}
+```
+
+
+```{r Setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+
+load("Resources\\Parameters.RData")
+
+if ("pacman" %in% rownames(installed.packages()) == FALSE) {
+  install.packages("pacman")
+}
+
+library(pacman)
+
+pacman::p_load(broom,
+               caret,
+               gtsummary,
+               irr,
+               readxl,
+               tidyverse,
+               writexl)
+
+### Recreate Needed Evaluation_[X]Defs Parameters from DefinitionInformation
+
+# Number of Validation Reviewers
+n_reviewers <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewerID %>% max()
+
+# ESSENCE fields included
+select_fields <- DefinitionInformation[["SelectFields"]] %>% filter(IncludeForValidationReview == "Yes") %>% pull(ESSENCEfields)
+
+# Jurisdiction of Validation Reviewers
+jurisdiction <- DefinitionInformation[["Setup"]]$Jurisdiction
+
+# Review Scale: High/Low
+ReviewScaleLow <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewScaleLow[1]
+ReviewScaleHigh <- DefinitionInformation[["ValidationReviewInformation"]]$ReviewScaleHigh[1]
+ReviewScale <- cut_review_scale(scale_low = ReviewScaleLow, scale_high = ReviewScaleHigh)
+
+# Extract Definition Undergoing Validation Review (from filepath)
+definition_abbrev <- str_extract(string = rstudioapi::getActiveDocumentContext()$path, # Gets the filepath of currently active R Markdown
+                          pattern = paste0(params$queries_abbrev, collapse = "|")) # Extract syndrome definition abbreviation from that filepath
+```
+
+```{r Load in All Reviewer Data}
+
+list_reviewer <- list()
+
+for(i in 1:n_reviewers){
+
+list_reviewer[[i]] <- readxl::read_excel(path = paste0("1_Reviewed_Data\\Reviewer_",i,"\\Reviewer_",i,"_Data.xlsx")) %>%
+  assign_review_label(df=.)
+
+names(list_reviewer)[[i]] <- paste0("Reviewer_",i)
+}
+
+# Save for Confusion Matrix Generation (line ~460)
+list_reviewer_cm <- list_reviewer 
+
+```
+
+```{r Join All Reviewer Data}
+if(n_reviewers > 1){
+  
+# Full Join All Reviewer Data Frames
+
+# Note: Each data frame will have added (_R#) suffixes added to their review columns. These suffixes can be used to identify individual reviewers once all of their review variables are joined together. (Ex: We have 3 reviewers you will see Review_Ratings_R[1-3], Review_Categories_R[1-3], Notes_R[1-3]).
+
+# Step 1: Set Aside Demographic and Clinical Variables
+demo_clinical <- list_reviewer[[1]] %>% # Using 1st data frame (exact same records and values across all reviewer DFs)
+    select(all_of(select_fields), -ends_with("\\_R[0-9]*")) # Select Validation Review fields, remove Rating vars. 
+
+
+# Step 2: Assign Reviewer ID (_R#) Suffixes to Each Reviewer Variable (to allow us to distinguish when all ratings are joined together)
+
+for(i in seq_along(list_reviewer)){
+  
+  list_reviewer[[i]] <- list_reviewer[[i]] %>%
+    rename_with(.data =.,
+                .cols = c(Review_Rating, Review_Category, Notes),
+                .fn = ~paste0(.,"_R",i))
+}
+
+# Step 3: Subset List Reviewer DFs to only 1) Date, 2) C_BioSense_ID, and Rating Variables.
+list_reviewer_ratings <- list()
+
+for(i in seq_along(list_reviewer)){
+  
+  list_reviewer_ratings[[i]] <- list_reviewer[[i]] %>%
+    select(Date, C_BioSense_ID, ends_with(paste0("R",i)))
+}
+  
+  
+# Step 4: Full Join Reviewer Ratings Together, Reorder Variables, and Left Join in Demographic and Clinical Variables
+
+comparison <- list_reviewer_ratings %>%
+  reduce(full_join, by = c("Date", "C_BioSense_ID")) %>%
+  # Reorder Variables: Needed to Create the Agreement Variable.
+  select(Date, C_BioSense_ID,
+         matches("Review\\_Rating"), ## Review_Rating(_R#) variable
+         matches("Review\\_Category"), # Reviewer_Category(_R#) variable
+         matches("^Notes"), # Notes(_R#) variable
+         everything()) %>%
+  left_join(., demo_clinical, by = join_by(Date, C_BioSense_ID))
+
+
+rm(list_reviewer_ratings)
+}
+```
+
+```{r Detect Agreements and Disagreements}
+if(n_reviewers > 1){
+  
+comparison <- comparison %>%
+  rowwise() %>%
+  mutate(Agreement =
+           all(c_across(Review_Category_R1:!!(paste0("Review_Category_R",n_reviewers))) ==
+                 first(c_across(Review_Category_R1:!!(paste0("Review_Category_R",n_reviewers))))), # Agreement assess the IRR of Qualitative Review Categories (FP/Uncertain/TP),
+         Date = as.Date(Date)) %>% 
+  ### Reorder variables ###
+  select(Date, C_BioSense_ID, Agreement, everything())
+
+}
+```
+
+<!-- Write Data -->
+
+```{r Write Consensus Dataset}
+if(n_reviewers > 1){
+ 
+  comparison %>%
+  arrange(Agreement) %>% # Disagreements at the top
+  mutate(Review_Category_Consensus = case_when(
+    Agreement == TRUE ~ Review_Category_R1,
+    TRUE ~ NA),
+    Notes_Consensus = ifelse(Agreement == TRUE, "-", NA)) %>%
+  select(Date, C_BioSense_ID, Agreement, Review_Category_Consensus, Notes_Consensus, everything()) %>%
+  writexl::write_xlsx(x=.,path = paste0("2_Consensus_Data\\Consensus_Data.xlsx")) 
+  
+}
+```
+
+---
+title: "Validation Summary (Pre Consensus Review): `r definition_abbrev`"
+---
+
+**Jurisdiction**: `r jurisdiction`  
+**Report Created**: `r Sys.Date()`    
+**Point of Contact**: `r DefinitionInformation[["Setup"]]$PointOfContact` (`r DefinitionInformation[["Setup"]]$POCEmail`)    
+**Organization**: `r DefinitionInformation[["Setup"]]$Organization`
+
+
+```{r Instructions Text, results= 'asis'}
+if(n_reviewers == 1){
+  
+  cat(paste0(
+    '# Instructions\n',
+    'After rendering this R Markdown report, syndrome definition performance metrics will be generated below (**Note: ** Records assigned the **Uncertain** review category will not be included in syndrome definition performance metric calculations).',
+    '<br> <br>'
+  ))
+  
+}else if(n_reviewers > 1){
+  
+  cat(paste0(
+    '# Consensus Review Instructions\n',
+    'After rendering this R Markdown report, validation reviews by each of the participating reviewers will be compared to assess agreement and disagreement for each reviewed record. Additionally, syndrome definition performance metrics (by reviewer) and interrater reliability metrics will be generated below. These metrics have been provided to assess how closely aligned participants were in their validation reviews and address any issues that may have emerged during the validation review process. (Note: Records assigned the **Uncertain** review category will not be included in syndrome definition performance metric calculations). \n',
+    'When you are ready to discuss validation review findings and come to a consensus decision among the participating reviewers (particularly for records where there were disagreements), access the following file:  **2_Consensus_Data/Consensus_Data.xlsx**.\n',
+    '\n',
+    '[Within **Consensus_Data.xlsx**:]{.underline}\n',
+    '\n',
+    '- Discuss records where there are disagreements between the participating reviewers (i.e. records where the **Agreement** variable will be **FALSE**).\n',
+    '- After a consensus decision has been made, fill in the **Review_Category_Consensus** variable with the agreed upon review category.\n',
+    '- (*Optional; if helpful*) Fill out the **Notes_Consensus** to explain which reviewer(s) changed their review category and rating upon coming to a consensus decision. This documentation will provide clarity as to how disagreements were resolved and what pieces of information may be useful to informing final record classifications\n',
+    '\n',
+    'After completing the consensus review process and running **Validation_Summary_Post_Consensus_Review.Rmd**, syndrome definition performance metrics (utilizing consensus review categories) will be generated. Additionally, **Consensus_Data.xlsx** will be copied and subset to remove the no longer needed *Reviewer* variables. This data will be called **Consensus_Data_Subset.xlsx**.',
+    '<br> <br>'
+    ))
+}
+
+```
+
+```{r Assessing Interrater Reliability Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('# Assessing Interrater Reliability  {.tabset}\n',
+           'Examining the initial agreement between the participating reviewers (**before Consensus Review**) can provide some insight into the reliability of the reviewer metrics as well as how difficult the reviewed definition was to classify. ')
+    )
+}
+```
+
+```{r Reviewer Distributions Setup}
+if(n_reviewers > 1){
+
+list_reviewer_comparison <- list()
+
+# To Showcase Distribution of Review Categories and Review Scales by Rater
+list_reviewer_comparison[["rating_categories"]] <- comparison %>%
+  select(C_BioSense_ID, matches("^Review_Category")) %>%
+  pivot_longer(data =., 
+               cols = contains("Review_Category"),
+               names_to = "Reviewer",
+               values_to = "Rating_Categories") %>%
+  mutate(Reviewer = str_replace_all(Reviewer, pattern = "Review_Category_R", replacement = "Reviewer "))
+
+list_reviewer_comparison[["rating_scales"]] <- comparison %>%
+  select(C_BioSense_ID, matches("^Review_Rating")) %>%
+  pivot_longer(data =., 
+               cols = contains("Review_Rating"),
+               names_to = "Reviewer",
+               values_to = "Rating_Scale") %>%
+  mutate(Reviewer = str_replace_all(Reviewer, pattern = "Review_Rating_R", replacement = "Reviewer "))
+
+
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["rating_categories"]] %>%
+  left_join(., list_reviewer_comparison[["rating_scales"]], by = join_by("C_BioSense_ID", "Reviewer")) %>%
+  mutate(Rating_Scale = factor(Rating_Scale,
+                                 levels = seq(from = ReviewScaleLow, to = ReviewScaleHigh, by = 1)))
+
+if(length(ReviewScale) == 2){
+  
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["distributions"]] %>%
+    mutate(Rating_Categories = factor(Rating_Categories, levels = c("False Positive", "True Positive")))
+  
+}else if(length(ReviewScale) == 3){
+  
+list_reviewer_comparison[["distributions"]] <- list_reviewer_comparison[["distributions"]] %>%
+    mutate(Rating_Categories = factor(Rating_Categories, levels = c("False Positive", "Uncertain","True Positive")))
+  
+}
+
+}
+```
+
+```{r Reviewer Distributions Text, results = 'asis'}
+if(n_reviewers > 1){
+
+cat(
+    paste0('## Reviewer Distributions\n',
+           'This sections examines the overall distributions of review categories (qualitative labels) and review ratings (quantitative values) applied by each reviewer.'
+    )
+  )
+  
+}
+```
+
+```{r Reviewer Distributions}
+if(n_reviewers > 1){
+
+list_reviewer_comparison[["distributions"]] %>% 
+  select(-C_BioSense_ID, `Rating Categories` = Rating_Categories, `Rating Scale` = Rating_Scale) %>%
+  tbl_summary(by = Reviewer,
+              missing_text = "Missing") %>%
+  add_p() %>%
+  add_overall(last=TRUE) %>%
+  modify_header(label ~ "") %>%
+  bold_labels()
+
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+```{r IRR Setup}
+if(n_reviewers > 1){
+ 
+# Generate Storage List
+list_reviewer_IRR <- list()
+
+# To Generate IRR Metrics
+
+comparison_IRR <- comparison %>%
+  select(matches("^Review_Rating")) # Include only the review columns with assigned values on the rating scale, removes other variables (ex: Review_TP_15_[REVIEWER#]). 
+  
+}
+```
+
+```{r Percent Agreement Review Categories Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('## Percent Agreement: Review Categories\n',
+           'This section examines the level of agreement across the **broad, qualitative review categories** applied to each record. For this validation review, the following review categories were utilized: ')
+  )
+}
+```
+
+```{r Print Review Categories}
+if(n_reviewers > 1){
+
+print(names(ReviewScale))
+
+}
+```
+
+```{r Percent Agreement Review Categories}
+if(n_reviewers > 1){
+
+n_agree <- comparison %>% filter(Agreement == TRUE) %>% nrow()
+n_sample <- comparison %>% nrow()
+pcnt_agree <- round((n_agree/n_sample)*100,1)
+
+list_reviewer_IRR[["Percent Agreement: Review Categories"]] <- paste0("Interrater Agreement:\n Records: ",n_sample,"\n Raters: ", n_reviewers,"\n %-agree: ", pcnt_agree)
+
+cat(list_reviewer_IRR[["Percent Agreement: Review Categories"]]) 
+  
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+```{r Percent Agreement Review Ratings Text, results = 'asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('## Percent Agreement: Review Ratings\n',
+           'This section examines the level of agreement across the **specific, quantitative review ratings** applied to each record. For this validation review, review ratings were nested within the review categories using the following schema: ')
+  )
+}
+```
+
+```{r Print ReviewScale}
+if(n_reviewers > 1){
+  
+  print(ReviewScale)
+}
+```
+
+```{r Percent Agreement Review Scales}
+if(n_reviewers > 1){
+
+(list_reviewer_IRR[["Percent Agreement: Review Ratings"]] <- comparison_IRR %>% irr::agree(.))
+
+}
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+`r if(n_reviewers == 2){paste0('## ','Cohens Kappa: Review Scales')}`
+`r if(n_reviewers > 2){paste0('## ','Lights Kappa: Review Scales')}`
+
+```{r Kappa Review Scales Text, results='asis'}
+if(n_reviewers > 1){
+  
+  cat(
+    paste0("Although Percent Agreement is a simple metric to quickly examine Interrater Reliability, it has a notable weakness. **Percent Agreement does not adjust for the level of agreement that would be expected by random chance, and therefore overestimates the level of agreement between reviewers**. The [Kappa statistic](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3402032/) is utilized to adress this weakness and can have values that range from 1 to -1. [Guidelines for examining Kappa values have suggested the following interpretation (although this may differ by use case):]{.underline}
+
+* **-1 to -0.1**: Agreement is worse than random (active disagreement)
+* **0 to 0.2**: Slight Agreement
+* **0.21 to 0.4**: Fair Agreement
+* **0.41 to 0.60**: Moderate Agreement
+* **0.61 to 0.80**: Substantial Agreement
+* **0.81 to 1.0**: Almost Perfect or Perfect Agreement"
+  ))
+  
+}
+```
+
+```{r Kappa Review Scales Description, results='asis'}
+if(n_reviewers == 2){
+  
+  cat("The Kappa statistic presented below is **Cohen's Kappa statistic** which was developed to assess interrater reliability between **2** reviewers.")
+  
+}else if(n_reviewers > 2){
+  
+  cat("The Kappa statistic presented below is **Light's Kappa statistic** developed to assess interrater reliability between **3+** reviewers. Specifically, Light's Kappa statistic is calculated by taking the average of the Cohen's Kappa stastic between all possible 2 reviewer pairs.")
+  
+}
+
+```
+
+```{r Quant Review Scale Kappa, warning = FALSE}
+
+# 3) Cohen's & Light's Kappa
+# Source: (Discussing appropriate use of IRR statistics) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3402032/
+
+if(n_reviewers == 2){ # Cohen's original Kappa only appropriate for 2 reviewers
+
+  (list_reviewer_IRR[["Cohen's Kappa"]] <- comparison_IRR %>% irr::kappa2(.))
+
+}else if(n_reviewers > 2){ # Light's Kappa - Average of all possible combinations of 2x2 Cohen Kappa's
+
+  (list_reviewer_IRR[["Light's Kappa"]] <- comparison_IRR %>% irr::kappam.light(.))
+}
+
+```
+
+```{r, results='asis'}
+if(n_reviewers > 1){
+  cat(
+    paste0('<br> <br>')
+    )
+}
+```
+
+# Syndrome Definition Performance (by Reviewer) {.tabset}
+
+```{r Syndrome Definition Performance by Reviewer}
+
+# Step 1: Prepare Data for Confusion Matrix
+
+for(i in 1:n_reviewers){
+  
+  list_reviewer_cm[[i]] <- list_reviewer_cm[[i]] %>% 
+    prep_cm(df=., use_case = "reviewer")
+}
+
+# Step 2: Dynamically Render Syndrome Definition Performance by Review Tabbed Widgets using list_reviewer. SOURCE: https://stackoverflow.com/questions/42631642/creating-dynamic-tabs-in-rmarkdown
+
+if(length(ReviewScale) == 2){ # TP, FP
+  
+  definition_performance_template <- c(
+    "```{r, echo=FALSE, results='asis'}\n",
+    "cat(
+    paste0('## ', 'Reviewer ', {{i}},' (',DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'))",
+    "```\n",
+    "\n",
+    "```{r}\n", # Initializes R code to create 1) Tabbed Widget and 2) Insert ES Text.
+    "list_reviewer_cm[[{{i}}]] %>% confusion_matrix(df=., use_case = 'reviewer')", # Print confusion matrix
+    "```\n", # Ends R Code and adds a space (to differentiate tabbed widgets)
+    "\n")
+  
+}else if(length(ReviewScale) == 3){ # TP, Uncertain, FP
+  
+    definition_performance_template <- c(
+    "```{r, echo=FALSE, results='asis'}\n",
+    "cat(
+    paste0('## ', 'Reviewer ',{{i}},' (', DefinitionInformation[['ValidationReviewInformation']]$ReviewerName[{{i}}],')','\n'),
+    paste0('**Note: ** Records with the review category of **Uncertain** are excluded from syndrome definition performance calculations.', '\n'))",
+    "```\n",
+    "\n",
+    "```{r}\n", # Initializes R code to create 1) Tabbed Widget and 2) Insert ES Text.
+    "list_reviewer_cm[[{{i}}]] %>% confusion_matrix(df=., use_case = 'reviewer')", # Print confusion matrix
+    "```\n", # Ends R Code and adds a space (to differentiate tabbed widgets)
+    "\n")
+}
+
+reviewer_definition_performance <- lapply(seq_along(list_reviewer), function(i) {knitr::knit_expand(text= definition_performance_template)}) # Use definition_performance_template above, and render it via knitr::knit_expand()
+
+```
+
+`r knitr::knit(text = unlist(reviewer_definition_performance))`
+
+```{r Write Reviewer RData File}
+if(n_reviewers == 1){
+  
+    save(list_reviewer, list_reviewer_cm, file = "1_Reviewed_Data\\Reviewer_Data.RData")
+  
+}else if(n_reviewers > 1){
+  
+  save(list_reviewer, list_reviewer_comparison, list_reviewer_cm, list_reviewer_IRR, file = "1_Reviewed_Data\\Reviewer_Data.RData")
+}
+```

--- a/run_tool.R
+++ b/run_tool.R
@@ -1,15 +1,15 @@
 # =======================================================================
-# Title: main.R
+# Title: run_tool.R
 
 # Description: 
 # Runs the syndrome evaluation toolkit.
 
 # =======================================================================
 
-#  ***USERS: CHANGE n_queries_eval BASED ON NEEDS*** -----
+# Number of Definitions to Evaluate -----
 
-## Define Number of Queries Being Evaluated (1-3: def1, def2, def3)
-n_queries_eval <- 2
+## [USERS CHANGE]: Define Number of Queries Being Evaluated (1-3: def1, def2, def3)
+n_queries_eval <- 2 # Change this to 1, 2, or 3.
 
 if(n_queries_eval > 3){stop("This tool can only analyze up to 3 syndromes simultaneously. Please change n_queries_eval to a value <= 3.")}
 

--- a/run_tool.R
+++ b/run_tool.R
@@ -9,7 +9,7 @@
 #  ***USERS: CHANGE n_queries_eval BASED ON NEEDS*** -----
 
 ## Define Number of Queries Being Evaluated (1-3: def1, def2, def3)
-n_queries_eval <- 3
+n_queries_eval <- 2
 
 if(n_queries_eval > 3){stop("This tool can only analyze up to 3 syndromes simultaneously. Please change n_queries_eval to a value <= 3.")}
 


### PR DESCRIPTION
Addresses issue #29 .

Changes made:
- Updates .gitignore to avoid accidentally ignoring Validation Review .Rmd templates
- Updates language throughout Validation Review .Rmd templates to say syndrome definition (instead of query)
- Updates cleaning of the Sex variable (used for Demographic tables of the main tool report) --> previously NA's were not being set to "Unknown" and therefore were being dropped from summary stats. This is fixed.
- Add rstudioapi R package --> allows for copying/finding of filepaths of currently opened Rmds
- Add DefinitionInformation (.xlsx table) into Parameters.RData for easy access for coding/development (does not change anything about how the tool runs, just makes it easier to reference user validation toolkit choices).